### PR TITLE
[spark-streamer] Fix: Increase ulimit for spark-streamers

### DIFF
--- a/image_content/config/spark/usr/local/lib/systemd/system/spark-streamer-1.service
+++ b/image_content/config/spark/usr/local/lib/systemd/system/spark-streamer-1.service
@@ -5,6 +5,8 @@ After=kafka.service clickhouse-server.service
 
 [Service]
 Type=simple
+LimitNOFILE=1617596
+LimitNOFILESoft=1617596
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/hadoop/bin
 Environment=JAVA_HOME=/usr/lib/jvm/default-java
 ExecStart=/opt/start-stream-receiver-local.sh

--- a/image_content/config/spark/usr/local/lib/systemd/system/spark-streamer-2.service
+++ b/image_content/config/spark/usr/local/lib/systemd/system/spark-streamer-2.service
@@ -5,6 +5,8 @@ After=kafka.service clickhouse-server.service spark-streamer-1.service
 
 [Service]
 Type=simple
+LimitNOFILE=1617596
+LimitNOFILESoft=1617596
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/hadoop/bin
 Environment=JAVA_HOME=/usr/lib/jvm/default-java
 ExecStart=/bin/sh -c "sleep 60 && exec /opt/start-stream-receiver-local-2.sh"


### PR DESCRIPTION
This fix #6 by setting *systemd ulimit* for single unit-files.

[Docs][1] for `LimitNOFILE`/`LimitNOFILESoft`.

[1]: https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Process%20Properties