### PR TITLE
[spark-streamer] Add clickhouse_port parameter to TecCalculation

### DIFF
--- a/image_content/config/spark/opt/start-stream-receiver-local-2.sh
+++ b/image_content/config/spark/opt/start-stream-receiver-local-2.sh
@@ -15,4 +15,5 @@
 	--conf spark.yarn.max.executor.failures=8 \
 	--conf spark.yarn.executor.failuresValidityInterval=1h \
 	/opt/spark/jars/novatel-streaming-assembly-1.0.jar \
-	12000000
+	st9-ape-ionosphere2s-1:8123 12000000
+        # ClickHouse # delay


### PR DESCRIPTION
До этого момента `spark-streamer-2` прибит гвоздями к шине на *localhost*,
в то время как `spark-streamer-1` имеет возможность указания шины на другом хосте.

Это PR добавляет дополнительный параметр в скрипт-обёртку для указания
целевого хоста у `spark-streamer-2`.