### PR TITLE
[compose] Fix ClickHouse mountpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,7 @@ services:
     volumes:
       - './image_content/config/clickhouse/etc/clickhouse-server/:/etc/clickhouse-server/'
       - './image_content/config/clickhouse_create_queries.sh:/docker-entrypoint-initdb.d/clickhouse_create_queries.sh'
-      - clickhouse_db:/var/lib/clickhouse/
+      - clickhouse_db:/data/ch/
 
   grafana:
     container_name: ionosphere-iif-grafana


### PR DESCRIPTION
Выставлена точка монтирования, соответствующая текущим настройкам ClickHouse.
Предыдущие настроки приводили к тому, что ClickHouse записывал данные внутрь
контейнера, не в раздел, что могло приводить к потере производительности и
нерациональному использованию диска.  