### PR TITLE
[grafana] Fix inconsistent sigNT

### DIFF
--- a/image_content/config/grafana-dashboards/ClickHouse New.json
+++ b/image_content/config/grafana-dashboards/ClickHouse New.json
@@ -1120,11 +1120,11 @@
           "hide": false,
           "interval": "",
           "intervalFactor": 1,
-          "query": "$columns(\n    'TEC deviation %sat %sigcomb',\n    avg(delNT) delNT)\nFROM $table\nWHERE\n    sat = '$satgraph'\n    and sigcomb in ($sigcomb)",
+          "query": "$columns(\n    'TEC deviation STD %sat %sigcomb',\n    avg(sigNT) sigNT)\nFROM $table\nWHERE\n    sat = '$satgraph'\n    and sigcomb in ($sigcomb)",
           "rawQuery": "SELECT t, groupArray((concat('TEC deviation ', sat, ' ', sigcomb), delNT)) as groupArr FROM ( SELECT intDiv(time, 2000) * 2000 as t, sat, sigcomb, avg(delNT) delNT FROM computed.NTDerivatives WHERE d >= toDate(1641383524120/1000) AND time >= 1641383524120 AND      sat = 'GPS30'     and sigcomb in ('L1CA+L2C','L1CA+L5Q') GROUP BY t, sat, sigcomb  ORDER BY t, sat, sigcomb) GROUP BY t ORDER BY t",
           "refId": "A",
           "round": "0s",
-          "table": "NTDerivatives",
+          "table": "xz1",
           "tableLoading": false
         }
       ],

--- a/image_content/config/grafana-dashboards/Суточный мониторинг.json
+++ b/image_content/config/grafana-dashboards/Суточный мониторинг.json
@@ -1034,11 +1034,11 @@
           "hide": false,
           "interval": "",
           "intervalFactor": 1,
-          "query": "$columns(\n    'TEC deviation %sat %sigcomb',\n    avg(delNT) delNT)\nFROM $table\nWHERE\n    sat = '$satgraph'\n    and sigcomb in ($sigcomb)",
+          "query": "$columns(\n    'TEC deviation STD %sat %sigcomb',\n    avg(sigNT) sigNT)\nFROM $table\nWHERE\n    sat = '$satgraph'\n    and sigcomb in ($sigcomb)",
           "rawQuery": "SELECT t, groupArray((concat('TEC deviation ', sat, ' ', sigcomb), delNT)) as groupArr FROM ( SELECT intDiv(time, 2000) * 2000 as t, sat, sigcomb, avg(delNT) delNT FROM computed.NTDerivatives WHERE d >= toDate(1650994878242/1000) AND time >= 1650994878242 AND      sat = 'GPS22'     and sigcomb in () GROUP BY t, sat, sigcomb  ORDER BY t, sat, sigcomb) GROUP BY t ORDER BY t",
           "refId": "A",
           "round": "0s",
-          "table": "NTDerivatives",
+          "table": "xz1",
           "tableLoading": false
         }
       ],


### PR DESCRIPTION
Значения, отображаемые на графиках *СКО флуктуаций ПЭС*, не соответсвуют описанию
из-за того что данные извлекались из неправильной таблицы.

Этот PR устанавливает таблицу `computed.xz` вместо `computed.NTDerivatives` в качестве источника
данных для графиков *СКО флуктуаций ПЭС*.