### PR TITLE
[Feature] `rawdata` to `computed` mirroring+compaction

### DIFF
--- a/docs/specs/database_layout/db_layout.md
+++ b/docs/specs/database_layout/db_layout.md
@@ -45,7 +45,7 @@ CREATE TABLE IF NOT EXISTS rawdata.ismredobs (
 ) ENGINE = MergeTree()
 PARTITION BY toYYYYMM(d)
 ORDER BY (time, sat, freq)
-TTL d + INTERVAL 1 WEEK DELETE
+TTL d + INTERVAL 1 DAY DELETE
 SETTINGS index_granularity=8192
 ```
 
@@ -67,7 +67,7 @@ CREATE TABLE IF NOT EXISTS rawdata.ismdetobs (
 ) ENGINE = MergeTree()
 PARTITION BY toYYYYMM(d)
 ORDER BY (time, sat, freq)
-TTL d + INTERVAL 1 WEEK DELETE
+TTL d + INTERVAL 1 DAY DELETE
 SETTINGS index_granularity=8192
 ```
 
@@ -90,7 +90,7 @@ CREATE TABLE IF NOT EXISTS rawdata.ismrawtec (
 ) ENGINE = MergeTree()
 PARTITION BY toYYYYMM(d)
 ORDER BY (time, sat, primaryfreq, secondaryfreq)
-TTL d + INTERVAL 1 WEEK DELETE
+TTL d + INTERVAL 1 DAY DELETE
 SETTINGS index_granularity=8192
 ```
 
@@ -110,7 +110,7 @@ CREATE TABLE rawdata.satxyz2 (
   prn Int32,
   d Date MATERIALIZED toDate(round(time / 1000))
 ) ENGINE = MergeTree(d, (time, sat), 8192)
-TTL d + INVERVAL 1 WEEK DELETE
+TTL d + INVERVAL 1 DAY DELETE
 ```
 
 ### Таблицы для расчетных данных
@@ -164,7 +164,7 @@ CREATE TABLE computed.s4 (
     s4 Float64 COMMENT 'S4',
     d Date MATERIALIZED toDate(round(time / 1000))
 ) ENGINE = ReplacingMergeTree(d, (time, sat, freq), 8192)
-TTL d + INTERVAL 1 Week DELETE
+TTL d + INTERVAL 2 MONTH DELETE
 ```
 
 #### Обычные таблицы
@@ -183,7 +183,7 @@ CREATE TABLE computed.NT (
     psrNt Float64 COMMENT 'ПЭС псевдодальностный',
     d Date MATERIALIZED toDate(round(time / 1000))
 ) ENGINE = ReplacingMergeTree(d, (time, sat, sigcomb), 8192)
-TTL d + INTERVAL 1 Week DELETE;
+TTL d + INTERVAL 2 MONTH DELETE;
 ```
 
 Источник: *computed.NT*

--- a/docs/specs/database_layout/db_layout.md
+++ b/docs/specs/database_layout/db_layout.md
@@ -24,7 +24,7 @@ CREATE TABLE rawdata.range (
   prn Int32,
   d Date MATERIALIZED toDate(round(time / 1000))
 ) ENGINE = MergeTree(d, (time, sat, freq), 8192)
-TTL d + INVERVAL 1 DAY DELETE
+TTL d + INVERVAL 24 HOUR DELETE
 ```
 
 #### rawdata.ismredobs
@@ -45,7 +45,7 @@ CREATE TABLE IF NOT EXISTS rawdata.ismredobs (
 ) ENGINE = MergeTree()
 PARTITION BY toYYYYMM(d)
 ORDER BY (time, sat, freq)
-TTL d + INTERVAL 1 DAY DELETE
+TTL d + INTERVAL 24 HOUR DELETE
 SETTINGS index_granularity=8192
 ```
 
@@ -67,7 +67,7 @@ CREATE TABLE IF NOT EXISTS rawdata.ismdetobs (
 ) ENGINE = MergeTree()
 PARTITION BY toYYYYMM(d)
 ORDER BY (time, sat, freq)
-TTL d + INTERVAL 1 DAY DELETE
+TTL d + INTERVAL 24 HOUR DELETE
 SETTINGS index_granularity=8192
 ```
 
@@ -90,7 +90,7 @@ CREATE TABLE IF NOT EXISTS rawdata.ismrawtec (
 ) ENGINE = MergeTree()
 PARTITION BY toYYYYMM(d)
 ORDER BY (time, sat, primaryfreq, secondaryfreq)
-TTL d + INTERVAL 1 DAY DELETE
+TTL d + INTERVAL 24 HOUR DELETE
 SETTINGS index_granularity=8192
 ```
 
@@ -110,7 +110,7 @@ CREATE TABLE rawdata.satxyz2 (
   prn Int32,
   d Date MATERIALIZED toDate(round(time / 1000))
 ) ENGINE = MergeTree(d, (time, sat), 8192)
-TTL d + INVERVAL 1 DAY DELETE
+TTL d + INVERVAL 24 HOUR DELETE
 ```
 
 ### Таблицы для расчетных данных

--- a/docs/specs/database_layout/db_layout.md
+++ b/docs/specs/database_layout/db_layout.md
@@ -149,6 +149,106 @@ GROUP BY
     freq
 ```
 
+##### computed.ismredobs
+
+Источник: *rawdata.ismredobs*  
+
+*Примечание:* для поддержки TTL необходима версия clickhouse>=19.6(1.1.54370)
+
+```sql
+CREATE MATERIALIZED VIEW computed.ismredobs
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(d)
+ORDER BY (time, sat, freq)
+TTL d + INTERVAL 2 MONTH DELETE
+SELECT
+    time,
+    totals4,
+    sat,
+    system,
+    freq,
+    glofreq,
+    prn,
+    d
+FROM rawdata.ismredobs
+```
+
+##### computed.ismdetobs
+
+Источник: *rawdata.ismdetobs*  
+
+*Примечание:* для поддержки TTL необходима версия clickhouse>=19.6(1.1.54370)
+
+```sql
+CREATE MATERIALIZED VIEW computed.ismdetobs
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(d)
+ORDER BY (time, sat, freq)
+TTL d + INTERVAL 2 MONTH DELETE
+POPULATE AS
+SELECT
+    time,
+    power,
+    sat,
+    system,
+    freq,
+    glofreq,
+    prn,
+    d
+FROM rawdata.ismdetobs
+```
+
+##### computed.ismrawtec
+
+Источник: *rawdata.ismrawtec*  
+
+*Примечание:* для поддержки TTL необходима версия clickhouse>=19.6(1.1.54370)
+
+```sql
+CREATE MATERIALIZED VIEW computed.ismrawtec
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(d)
+ORDER BY (time, sat, primaryfreq, secondaryfreq)
+TTL d + INTERVAL 2 MONTH DELETE
+POPULATE AS
+SELECT
+    time,
+    tec,
+    sat,
+    system,
+    primaryfreq,
+    secondaryfreq,
+    glofreq,
+    prn,
+    d
+FROM rawdata.ismrawtec
+```
+
+##### computed.satxyz2
+
+Источник: *rawdata.satxyz2*  
+
+*Примечание:* для поддержки TTL необходима версия clickhouse>=19.6(1.1.54370)
+
+```sql
+CREATE MATERIALIZED VIEW computed.satxyz2
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(d)
+ORDER BY (time, sat)
+TTL d + INTERVAL 2 MONTH DELETE
+POPULATE AS
+SELECT
+    time,
+    geopoint,
+    ionpoint,
+    elevation,
+    sat,
+    system,
+    prn,
+    d
+FROM rawdata.satxyz2
+```
+
 ##### computed.s4
 
 Источник: *rawdata.range*  

--- a/docs/specs/database_layout/db_layout.md
+++ b/docs/specs/database_layout/db_layout.md
@@ -1,4 +1,4 @@
-v11 clickhouse database layout
+v12 clickhouse database layout
 =============================
 
 ### Таблицы для входных данных
@@ -116,6 +116,38 @@ TTL d + INVERVAL 1 WEEK DELETE
 ### Таблицы для расчетных данных
 
 #### Односекундные таблицы
+
+##### computed.range
+
+Источник: *rawdata.range*  
+
+*Примечание:* для поддержки TTL необходима версия clickhouse>=19.6(1.1.54370)
+
+```sql
+CREATE MATERIALIZED VIEW computed.range
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(d)
+ORDER BY (time, sat, freq)
+TTL d + INTERVAL 2 MONTH DELETE
+POPULATE AS
+SELECT
+    time,
+    avg(adr) AS adr,
+    avg(psr) AS psr,
+    avg(cno) AS cno,
+    any(locktime) AS locktime,
+    sat,
+    any(system) AS system,
+    freq,
+    any(glofreq) AS glofreq,
+    any(prn) AS prn,
+    any(d) AS d
+FROM rawdata.range
+GROUP BY
+    (intDiv(time, 1000) * 1000) AS time,
+    sat,
+    freq
+```
 
 ##### computed.s4
 

--- a/image_content/config/clickhouse_create_queries.sh
+++ b/image_content/config/clickhouse_create_queries.sh
@@ -130,6 +130,83 @@ GROUP BY
 EOL123
 
 clickhouse-client <<EOL123
+CREATE MATERIALIZED VIEW IF NOT EXISTS computed.ismredobs
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(d)
+ORDER BY (time, sat, freq)
+TTL d + INTERVAL 2 MONTH DELETE
+POPULATE AS
+SELECT
+    time,
+    totals4,
+    sat,
+    system,
+    freq,
+    glofreq,
+    prn,
+    d
+FROM rawdata.ismredobs
+EOL123
+
+clickhouse-client <<EOL123
+CREATE MATERIALIZED VIEW IF NOT EXISTS computed.ismdetobs
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(d)
+ORDER BY (time, sat, freq)
+TTL d + INTERVAL 2 MONTH DELETE
+POPULATE AS
+SELECT
+    time,
+    power,
+    sat,
+    system,
+    freq,
+    glofreq,
+    prn,
+    d
+FROM rawdata.ismdetobs
+EOL123
+
+clickhouse-client <<EOL123
+CREATE MATERIALIZED VIEW IF NOT EXISTS computed.ismrawtec
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(d)
+ORDER BY (time, sat, primaryfreq, secondaryfreq)
+TTL d + INTERVAL 2 MONTH DELETE
+POPULATE AS
+SELECT
+    time,
+    tec,
+    sat,
+    system,
+    primaryfreq,
+    secondaryfreq,
+    glofreq,
+    prn,
+    d
+FROM rawdata.ismrawtec
+EOL123
+
+clickhouse-client <<EOL123
+CREATE MATERIALIZED VIEW IF NOT EXISTS computed.satxyz2
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(d)
+ORDER BY (time, sat)
+TTL d + INTERVAL 2 MONTH DELETE
+POPULATE AS
+SELECT
+    time,
+    geopoint,
+    ionpoint,
+    elevation,
+    sat,
+    system,
+    prn,
+    d
+FROM rawdata.satxyz2
+EOL123
+
+clickhouse-client <<EOL123
 CREATE TABLE IF NOT EXISTS computed.s4 (
   time UInt64,
   sat String,

--- a/image_content/config/clickhouse_create_queries.sh
+++ b/image_content/config/clickhouse_create_queries.sh
@@ -30,7 +30,7 @@ CREATE TABLE IF NOT EXISTS rawdata.range (
 ) ENGINE = MergeTree()
 PARTITION BY toYYYYMM(d)
 ORDER BY (time, sat, freq)
-TTL d + INTERVAL 1 DAY DELETE
+TTL d + INTERVAL 24 HOUR DELETE
 SETTINGS index_granularity=8192
 EOL123
 
@@ -47,7 +47,7 @@ CREATE TABLE IF NOT EXISTS rawdata.ismredobs (
 ) ENGINE = MergeTree()
 PARTITION BY toYYYYMM(d)
 ORDER BY (time, sat, freq)
-TTL d + INTERVAL 1 DAY DELETE
+TTL d + INTERVAL 24 HOUR DELETE
 SETTINGS index_granularity=8192
 EOL123
 
@@ -64,7 +64,7 @@ CREATE TABLE IF NOT EXISTS rawdata.ismdetobs (
 ) ENGINE = MergeTree()
 PARTITION BY toYYYYMM(d)
 ORDER BY (time, sat, freq)
-TTL d + INTERVAL 1 DAY DELETE
+TTL d + INTERVAL 24 HOUR DELETE
 SETTINGS index_granularity=8192
 EOL123
 
@@ -82,7 +82,7 @@ CREATE TABLE IF NOT EXISTS rawdata.ismrawtec (
 ) ENGINE = MergeTree()
 PARTITION BY toYYYYMM(d)
 ORDER BY (time, sat, primaryfreq, secondaryfreq)
-TTL d + INTERVAL 1 DAY DELETE
+TTL d + INTERVAL 24 HOUR DELETE
 SETTINGS index_granularity=8192
 EOL123
 
@@ -99,7 +99,7 @@ CREATE TABLE IF NOT EXISTS rawdata.satxyz2 (
 ) ENGINE = MergeTree()
 PARTITION BY toYYYYMM(d)
 ORDER BY (time, sat)
-TTL d + INTERVAL 1 DAY DELETE
+TTL d + INTERVAL 24 HOUR DELETE
 SETTINGS index_granularity=8192
 EOL123
 

--- a/image_content/config/clickhouse_create_queries.sh
+++ b/image_content/config/clickhouse_create_queries.sh
@@ -47,7 +47,7 @@ CREATE TABLE IF NOT EXISTS rawdata.ismredobs (
 ) ENGINE = MergeTree()
 PARTITION BY toYYYYMM(d)
 ORDER BY (time, sat, freq)
-TTL d + INTERVAL 1 WEEK DELETE
+TTL d + INTERVAL 1 DAY DELETE
 SETTINGS index_granularity=8192
 EOL123
 
@@ -64,7 +64,7 @@ CREATE TABLE IF NOT EXISTS rawdata.ismdetobs (
 ) ENGINE = MergeTree()
 PARTITION BY toYYYYMM(d)
 ORDER BY (time, sat, freq)
-TTL d + INTERVAL 1 WEEK DELETE
+TTL d + INTERVAL 1 DAY DELETE
 SETTINGS index_granularity=8192
 EOL123
 
@@ -82,7 +82,7 @@ CREATE TABLE IF NOT EXISTS rawdata.ismrawtec (
 ) ENGINE = MergeTree()
 PARTITION BY toYYYYMM(d)
 ORDER BY (time, sat, primaryfreq, secondaryfreq)
-TTL d + INTERVAL 1 WEEK DELETE
+TTL d + INTERVAL 1 DAY DELETE
 SETTINGS index_granularity=8192
 EOL123
 
@@ -99,7 +99,7 @@ CREATE TABLE IF NOT EXISTS rawdata.satxyz2 (
 ) ENGINE = MergeTree()
 PARTITION BY toYYYYMM(d)
 ORDER BY (time, sat)
-TTL d + INTERVAL 1 WEEK DELETE
+TTL d + INTERVAL 1 DAY DELETE
 SETTINGS index_granularity=8192
 EOL123
 
@@ -139,7 +139,7 @@ CREATE TABLE IF NOT EXISTS computed.s4 (
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(d)
 ORDER BY (time, sat, freq)
-TTL d + INTERVAL 1 WEEK DELETE
+TTL d + INTERVAL 2 MONTH DELETE
 SETTINGS index_granularity=8192
 EOL123
 
@@ -156,7 +156,7 @@ CREATE TABLE IF NOT EXISTS computed.NT (
 ) ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(d)
 ORDER BY (time, sat, sigcomb)
-TTL d + INTERVAL 1 WEEK DELETE
+TTL d + INTERVAL 2 MONTH DELETE
 SETTINGS index_granularity=8192
 EOL123
 

--- a/image_content/config/grafana-dashboards/TEC.json
+++ b/image_content/config/grafana-dashboards/TEC.json
@@ -79,7 +79,7 @@
           "tableLoading": false
         },
         {
-          "database": "rawdata",
+          "database": "computed",
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -96,7 +96,7 @@
           "tableLoading": false
         },
         {
-          "database": "rawdata",
+          "database": "computed",
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",

--- a/image_content/config/grafana-dashboards/Суточный мониторинг.json
+++ b/image_content/config/grafana-dashboards/Суточный мониторинг.json
@@ -253,7 +253,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "database": "rawdata",
+          "database": "computed",
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -270,7 +270,7 @@
           "tableLoading": false
         },
         {
-          "database": "rawdata",
+          "database": "computed",
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -611,7 +611,7 @@
       "targets": [
         {
           "aggregator": "sum",
-          "database": "rawdata",
+          "database": "computed",
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -726,7 +726,7 @@
       "targets": [
         {
           "aggregator": "sum",
-          "database": "rawdata",
+          "database": "computed",
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -941,7 +941,7 @@
       "satTag": "sat",
       "targets": [
         {
-          "database": "rawdata",
+          "database": "computed",
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -1097,14 +1097,14 @@
           "value": "GLONASS5"
         },
         "datasource": "ClickHouse",
-        "definition": "",
+        "definition": "select distinct(sat) from computed.satxyz2 where time between $from and $to",
         "hide": 0,
         "includeAll": false,
         "label": "",
         "multi": true,
         "name": "satvis",
         "options": [],
-        "query": "select distinct(sat) from rawdata.satxyz2 where time between $from and $to",
+        "query": "select distinct(sat) from computed.satxyz2 where time between $from and $to",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -1123,14 +1123,14 @@
           "value": "GPS22"
         },
         "datasource": "ClickHouse",
-        "definition": "",
+        "definition": "select distinct(sat) from computed.satxyz2 where time between $from and $to",
         "hide": 0,
         "includeAll": false,
         "label": "",
         "multi": false,
         "name": "satgraph",
         "options": [],
-        "query": "select distinct(sat) from rawdata.satxyz2 where time between $from and $to",
+        "query": "select distinct(sat) from computed.satxyz2 where time between $from and $to",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -1148,14 +1148,14 @@
           "value": "L1CA"
         },
         "datasource": "ClickHouse",
-        "definition": "select distinct(freq) from rawdata.range where sat='$satgraph' and time between $from and $to",
+        "definition": "select distinct(freq) from computed.range where sat='$satgraph' and time between $from and $to",
         "hide": 0,
         "includeAll": false,
         "label": null,
         "multi": true,
         "name": "freq",
         "options": [],
-        "query": "select distinct(freq) from rawdata.range where sat='$satgraph' and time between $from and $to",
+        "query": "select distinct(freq) from computed.range where sat='$satgraph' and time between $from and $to",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -1198,14 +1198,14 @@
           "value": "$__all"
         },
         "datasource": "ClickHouse",
-        "definition": "select distinct(secondaryfreq) from rawdata.ismrawtec where sat='$satgraph' and time between $from and $to",
+        "definition": "select distinct(secondaryfreq) from computed.ismrawtec where sat='$satgraph' and time between $from and $to",
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "TEC_secondaryfreq",
         "options": [],
-        "query": "select distinct(secondaryfreq) from rawdata.ismrawtec where sat='$satgraph' and time between $from and $to",
+        "query": "select distinct(secondaryfreq) from computed.ismrawtec where sat='$satgraph' and time between $from and $to",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,


### PR DESCRIPTION
Добавлены MATERIALIZED-таблицы, дублирующие `rawdata`-таблицы с понижением
плотности записей:

- `computed.range` <= `rawdata.range`
- `computed.ismredobs` <= `rawdata.ismredobs`
- `computed.ismdetobs` <= `rawdata.ismdetobs`
- `computed.ismrawtec` <= `rawdata.ismrawtec`
- `computed.satxyz2` <= `rawdata.satxyz2`

Таблицы `rawdata` теперь хранятся 24 часа, `computed` -- 2 месяца.

Соответствующие дашборы переведены на `computed`.