### PR TITLE
[grafana] Limit `sigNT` on monitoring dashboard

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,7 @@ services:
     ports:
       - 3000:3000
     volumes:
+      - './image_content/config/grafana/etc/grafana/grafana.ini:/etc/grafana/grafana.ini'
       - './image_content/config/grafana/etc/grafana/provisioning/:/etc/grafana/provisioning/'
       - './image_content/config/grafana-dashboards/:/var/lib/grafana/dashboards/'
     depends_on:

--- a/image_content/config/grafana-dashboards/Суточный мониторинг.json
+++ b/image_content/config/grafana-dashboards/Суточный мониторинг.json
@@ -1065,7 +1065,7 @@
           "format": "none",
           "label": "TECU",
           "logBase": 1,
-          "max": null,
+          "max": "0.05",
           "min": null,
           "show": true
         },

--- a/image_content/config/grafana/etc/grafana/grafana.ini
+++ b/image_content/config/grafana/etc/grafana/grafana.ini
@@ -4,29 +4,31 @@
 # change
 
 # possible values : production, development
-; app_mode = production
+;app_mode = production
 
 # instance name, defaults to HOSTNAME environment variable value or hostname if HOSTNAME var is empty
-; instance_name = ${HOSTNAME}
+;instance_name = ${HOSTNAME}
 
 #################################### Paths ####################################
 [paths]
 # Path to where grafana can store temp files, sessions, and the sqlite3 db (if that is used)
-#
 ;data = /var/lib/grafana
-#
+
+# Temporary files in `data` directory older than given duration will be removed
+;temp_data_lifetime = 24h
+
 # Directory where grafana can store logs
-#
 ;logs = /var/log/grafana
-#
+
 # Directory where grafana will automatically scan and look for plugins
-#
 ;plugins = /var/lib/grafana/plugins
 
-#
+# folder that contains provisioning config files that grafana will apply on startup and while running.
+;provisioning = conf/provisioning
+
 #################################### Server ####################################
 [server]
-# Protocol (http or https)
+# Protocol (http, https, socket)
 ;protocol = http
 
 # The ip address to bind to, empty will bind to all interfaces
@@ -59,17 +61,20 @@
 ;cert_file =
 ;cert_key =
 
+# Unix socket path
+;socket =
+
 #################################### Database ####################################
 [database]
 # You can configure the database connection by specifying type, host, name, user and password
-# as seperate properties or as on string using the url propertie.
+# as separate properties or as on string using the url properties.
 
 # Either "mysql", "postgres" or "sqlite3", it's your choice
 ;type = sqlite3
 ;host = 127.0.0.1:3306
 ;name = grafana
 ;user = root
-# If the password contains # or ; you have to wrap it with trippel quotes. Ex """#password;"""
+# If the password contains # or ; you have to wrap it with triple quotes. Ex """#password;"""
 ;password =
 
 # Use either URL or the previous fields to configure the database
@@ -82,33 +87,31 @@
 # For "sqlite3" only, path relative to data_path setting
 ;path = grafana.db
 
+# Max idle conn setting default is 2
+;max_idle_conn = 2
+
 # Max conn setting default is 0 (mean not set)
-;max_conn =
-;max_idle_conn =
 ;max_open_conn =
 
+# Connection Max Lifetime default is 14400 (means 14400 seconds or 4 hours)
+;conn_max_lifetime = 14400
 
-#################################### Session ####################################
-[session]
-# Either "memory", "file", "redis", "mysql", "postgres", default is "file"
-;provider = file
+# Set to true to log the sql calls and execution times.
+log_queries =
 
-# Provider config options
-# memory: not have any config yet
-# file: session dir path, is relative to grafana data_path
-# redis: config like redis server e.g. `addr=127.0.0.1:6379,pool_size=100,db=grafana`
-# mysql: go-sql-driver/mysql dsn config string, e.g. `user:password@tcp(127.0.0.1:3306)/database_name`
-# postgres: user=a password=b host=localhost port=5432 dbname=c sslmode=disable
-;provider_config = sessions
+# For "sqlite3" only. cache mode setting used for connecting to the database. (private, shared)
+;cache_mode = private
 
-# Session cookie name
-;cookie_name = grafana_sess
+#################################### Cache server #############################
+[remote_cache]
+# Either "redis", "memcached" or "database" default is "database"
+;type = database
 
-# If you use session in https only, default is false
-;cookie_secure = false
-
-# Session life time, default is 86400
-;session_life_time = 86400
+# cache connectionstring options
+# database: will use Grafana primary database.
+# redis: config like redis server e.g. `addr=127.0.0.1:6379,pool_size=100,db=0`. Only addr is required.
+# memcache: 127.0.0.1:11211
+;connstr =
 
 #################################### Data proxy ###########################
 [dataproxy]
@@ -116,6 +119,11 @@
 # This enables data proxy logging, default is false
 ;logging = false
 
+# How long the data proxy should wait before timing out default is 30 (seconds)
+;timeout = 30
+
+# If enabled and user is not anonymous, data proxy will add X-Grafana-User header with username into the request, default is false.
+;send_user_header = false
 
 #################################### Analytics ####################################
 [analytics]
@@ -129,11 +137,14 @@
 # for new vesions (grafana itself and plugins), check is used
 # in some UI views to notify that grafana or plugin update exists
 # This option does not cause any auto updates, nor send any information
-# only a GET request to http://grafana.net to get latest versions
+# only a GET request to http://grafana.com to get latest versions
 ;check_for_updates = true
 
 # Google Analytics universal tracking code, only enabled if you specify an id here
 ;google_analytics_ua_id =
+
+# Google Tag Manager ID, only enabled if you specify an id here
+;google_tag_manager_id =
 
 #################################### Security ####################################
 [security]
@@ -146,17 +157,49 @@
 # used for signing
 ;secret_key = SW2YcwTIb9zpOOhoPsMm
 
-# Auto-login remember days
-;login_remember_days = 7
-;cookie_username = grafana_user
-;cookie_remember_name = grafana_remember
-
 # disable gravatar profile images
 ;disable_gravatar = false
 
 # data source proxy whitelist (ip_or_domain:port separated by spaces)
 ;data_source_proxy_whitelist =
 
+# disable protection against brute force login attempts
+;disable_brute_force_login_protection = false
+
+# set to true if you host Grafana behind HTTPS. default is false.
+;cookie_secure = false
+
+# set cookie SameSite attribute. defaults to `lax`. can be set to "lax", "strict" and "none"
+;cookie_samesite = lax
+
+# set to true if you want to allow browsers to render Grafana in a <frame>, <iframe>, <embed> or <object>. default is false.
+;allow_embedding = false
+
+# Set to true if you want to enable http strict transport security (HSTS) response header.
+# This is only sent when HTTPS is enabled in this configuration.
+# HSTS tells browsers that the site should only be accessed using HTTPS.
+# The default version will change to true in the next minor release, 6.3.
+;strict_transport_security = false
+
+# Sets how long a browser should cache HSTS. Only applied if strict_transport_security is enabled.
+;strict_transport_security_max_age_seconds = 86400
+
+# Set to true if to enable HSTS preloading option. Only applied if strict_transport_security is enabled.
+;strict_transport_security_preload = false
+
+# Set to true if to enable the HSTS includeSubDomains option. Only applied if strict_transport_security is enabled.
+;strict_transport_security_subdomains = false
+
+# Set to true to enable the X-Content-Type-Options response header.
+# The X-Content-Type-Options response HTTP header is a marker used by the server to indicate that the MIME types advertised
+# in the Content-Type headers should not be changed and be followed. The default will change to true in the next minor release, 6.3.
+;x_content_type_options = false
+
+# Set to true to enable the X-XSS-Protection header, which tells browsers to stop pages from loading
+# when they detect reflected cross-site scripting (XSS) attacks. The default will change to true in the next minor release, 6.3.
+;x_xss_protection = false
+
+#################################### Snapshots ###########################
 [snapshots]
 # snapshot sharing options
 ;external_enabled = true
@@ -166,10 +209,12 @@
 # remove expired snapshot
 ;snapshot_remove_expired = true
 
-# remove snapshots after 90 days
-;snapshot_TTL_days = 90
+#################################### Dashboards History ##################
+[dashboards]
+# Number dashboard versions to keep (per dashboard). Default: 20, Minimum: 1
+;versions_to_keep = 20
 
-#################################### Users ####################################
+#################################### Users ###############################
 [users]
 # disable user signup / registration
 ;allow_sign_up = true
@@ -185,15 +230,49 @@
 
 # Background text for the user field on the login page
 ;login_hint = email or username
+;password_hint = password
 
 # Default UI theme ("dark" or "light")
 ;default_theme = dark
 
+# External user management, these options affect the organization users view
+;external_manage_link_url =
+;external_manage_link_name =
+;external_manage_info =
+
+# Viewers can edit/inspect dashboard settings in the browser. But not save the dashboard.
+;viewers_can_edit = false
+
+# Editors can administrate dashboard, folders and teams they create
+;editors_can_admin = false
+
 [auth]
+# Login cookie name
+;login_cookie_name = grafana_session
+
+# The lifetime (days) an authenticated user can be inactive before being required to login at next visit. Default is 7 days,
+;login_maximum_inactive_lifetime_days = 7
+
+# The maximum lifetime (days) an authenticated user can be logged in since login time before being required to login. Default is 30 days.
+;login_maximum_lifetime_days = 30
+
+# How often should auth tokens be rotated for authenticated users when being active. The default is each 10 minutes.
+;token_rotation_interval_minutes = 10
+
 # Set to true to disable (hide) the login form, useful if you use OAuth, defaults to false
 ;disable_login_form = false
 
-#################################### Anonymous Auth ##########################
+# Set to true to disable the signout link in the side menu. useful if you use auth.proxy, defaults to false
+;disable_signout_menu = false
+
+# URL to redirect the user to after sign out
+;signout_redirect_url =
+
+# Set to true to attempt login with OAuth automatically, skipping the login screen.
+# This setting is ignored if multiple OAuth providers are configured.
+;oauth_auto_login = false
+
+#################################### Anonymous Auth ######################
 [auth.anonymous]
 # enable anonymous access
 ;enabled = false
@@ -242,9 +321,17 @@
 ;api_url = https://foo.bar/user
 ;team_ids =
 ;allowed_organizations =
+;tls_skip_verify_insecure = false
+;tls_client_cert =
+;tls_client_key =
+;tls_client_ca =
 
-#################################### Grafana.net Auth ####################
-[auth.grafananet]
+; Set to true to enable sending client_id and client_secret via POST body instead of Basic authentication HTTP header
+; This might be required if the OAuth provider is not RFC6749 compliant, only supporting credentials passed via POST payload
+;send_client_credentials_via_post = false
+
+#################################### Grafana.com Auth ####################
+[auth.grafana_com]
 ;enabled = false
 ;allow_sign_up = true
 ;client_id = some_id
@@ -260,6 +347,7 @@
 ;auto_sign_up = true
 ;ldap_sync_ttl = 60
 ;whitelist = 192.168.1.1, 192.168.2.1
+;headers = Email:X-User-Email, Name:X-User-Name
 
 #################################### Basic Auth ##########################
 [auth.basic]
@@ -283,6 +371,8 @@
 ;skip_verify = false
 ;from_address = admin@grafana.localhost
 ;from_name = Grafana
+# EHLO identity in SMTP dialog (defaults to instance_name)
+;ehlo_identity = dashboard.example.com
 
 [emails]
 ;welcome_email_on_sign_up = false
@@ -293,12 +383,11 @@
 # Use space to separate multiple modes, e.g. "console file"
 ;mode = console file
 
-# Either "trace", "debug", "info", "warn", "error", "critical", default is "info"
+# Either "debug", "info", "warn", "error", "critical", default is "info"
 ;level = info
 
 # optional settings to set different levels for specific loggers. Ex filters = sqlstore:debug
 ;filters =
-
 
 # For "console" mode only
 [log.console]
@@ -345,18 +434,6 @@
 # Syslog tag. By default, the process' argv[0] is used.
 ;tag =
 
-
-#################################### AMQP Event Publisher ##########################
-[event_publisher]
-;enabled = false
-;rabbitmq_url = amqp://localhost/
-;exchange = grafana_events
-
-;#################################### Dashboard JSON files ##########################
-[dashboards.json]
-;enabled = false
-;path = /var/lib/grafana/dashboards
-
 #################################### Alerting ############################
 [alerting]
 # Disable alerting engine & UI features
@@ -364,8 +441,33 @@
 # Makes it possible to turn off alert rule execution but alerting UI is visible
 ;execute_alerts = true
 
+# Default setting for new alert rules. Defaults to categorize error and timeouts as alerting. (alerting, keep_state)
+;error_or_timeout = alerting
+
+# Default setting for how Grafana handles nodata or null values in alerting. (alerting, no_data, keep_state, ok)
+;nodata_or_nullvalues = no_data
+
+# Alert notifications can include images, but rendering many images at the same time can overload the server
+# This limit will protect the server from render overloading and make sure notifications are sent out quickly
+;concurrent_render_limit = 5
+
+
+# Default setting for alert calculation timeout. Default value is 30
+;evaluation_timeout_seconds = 30
+
+# Default setting for alert notification timeout. Default value is 30
+;notification_timeout_seconds = 30
+
+# Default setting for max attempts to sending alert notifications. Default value is 3
+;max_attempts = 3
+
+#################################### Explore #############################
+[explore]
+# Enable the Explore section
+;enabled = true
+
 #################################### Internal Grafana Metrics ##########################
-# Metrics available at HTTP API Url /api/metrics
+# Metrics available at HTTP API Url /metrics
 [metrics]
 # Disable / Enable internal metrics
 ;enabled           = true
@@ -379,23 +481,74 @@
 ;address =
 ;prefix = prod.grafana.%(instance_name)s.
 
-#################################### Internal Grafana Metrics ##########################
-# Url used to to import dashboards directly from Grafana.net
-[grafana_net]
-;url = https://grafana.net
+#################################### Distributed tracing ############
+[tracing.jaeger]
+# Enable by setting the address sending traces to jaeger (ex localhost:6831)
+;address = localhost:6831
+# Tag that will always be included in when creating new spans. ex (tag1:value1,tag2:value2)
+;always_included_tag = tag1:value1
+# Type specifies the type of the sampler: const, probabilistic, rateLimiting, or remote
+;sampler_type = const
+# jaeger samplerconfig param
+# for "const" sampler, 0 or 1 for always false/true respectively
+# for "probabilistic" sampler, a probability between 0 and 1
+# for "rateLimiting" sampler, the number of spans per second
+# for "remote" sampler, param is the same as for "probabilistic"
+# and indicates the initial sampling rate before the actual one
+# is received from the mothership
+;sampler_param = 1
+
+#################################### Grafana.com integration  ##########################
+# Url used to import dashboards directly from Grafana.com
+[grafana_com]
+;url = https://grafana.com
 
 #################################### External image storage ##########################
 [external_image_storage]
 # Used for uploading images to public servers so they can be included in slack/email messages.
-# you can choose between (s3, webdav)
+# you can choose between (s3, webdav, gcs, azure_blob, local)
 ;provider =
 
 [external_image_storage.s3]
-;bucket_url =
+;bucket =
+;region =
+;path =
 ;access_key =
 ;secret_key =
 
 [external_image_storage.webdav]
 ;url =
+;public_url =
 ;username =
 ;password =
+
+[external_image_storage.gcs]
+;key_file =
+;bucket =
+;path =
+
+[external_image_storage.azure_blob]
+;account_name =
+;account_key =
+;container_name =
+
+[external_image_storage.local]
+# does not require any configuration
+
+[rendering]
+# Options to configure external image rendering server like https://github.com/grafana/grafana-image-renderer
+;server_url =
+;callback_url =
+
+[enterprise]
+# Path to a valid Grafana Enterprise license.jwt file
+;license_path =
+
+[panels]
+# If set to true Grafana will allow script tags in text panels. Not recommended as it enable XSS vulnerabilities.
+;disable_sanitize_html = false
+
+[plugins]
+;enable_alpha = false
+;app_tls_skip_verify_insecure = false
+

--- a/image_content/config/grafana/etc/grafana/grafana.ini
+++ b/image_content/config/grafana/etc/grafana/grafana.ini
@@ -233,7 +233,7 @@ log_queries =
 ;password_hint = password
 
 # Default UI theme ("dark" or "light")
-;default_theme = dark
+default_theme = light
 
 # External user management, these options affect the organization users view
 ;external_manage_link_url =


### PR DESCRIPTION
Временное решение проблемы всплесков `sigNT` на дашборде суточного мониторинга.
Всплески можно игнорировать при ручной подгонке графиков, но в `reporter` не реализована
функциональность выделения пролётов спутников.

Дополнительно включил светлую тему, т.к. она лучше подходит для скриншотов.
