### PR TITLE
Fix: add lost S4 of Sigma_Phi

### DIFF
--- a/docs/specs/database_layout/db_layout.md
+++ b/docs/specs/database_layout/db_layout.md
@@ -1,4 +1,4 @@
-v13 clickhouse database layout
+v14 clickhouse database layout
 =============================
 
 ### Таблицы для входных данных

--- a/docs/specs/database_layout/db_layout.md
+++ b/docs/specs/database_layout/db_layout.md
@@ -249,15 +249,15 @@ SELECT
 FROM rawdata.satxyz2
 ```
 
-##### computed.s4
+##### computed.s4pwr
 
 Источник: *rawdata.range*  
-*Примечание:* s4 считается для частот, а не для их комбинаций.  
+*Примечание:* Эта S4 считается для частот, а не для их комбинаций.  
 
 *Примечание:* для поддержки TTL необходима версия clickhouse>=19.6(1.1.54370)
 
 ```sql
-CREATE TABLE computed.s4 (
+CREATE TABLE computed.s4pwr (
     time UInt64 COMMENT 'Метка времени (timestamp в ms)',
     sat String COMMENT 'Спутник',
     freq String COMMENT 'Частота, для которой рассчитано значение',

--- a/docs/specs/database_layout/db_layout.md
+++ b/docs/specs/database_layout/db_layout.md
@@ -249,6 +249,23 @@ SELECT
 FROM rawdata.satxyz2
 ```
 
+##### computed.s4
+
+Источник: *rawdata.range*  
+
+*Примечание:* для поддержки TTL необходима версия clickhouse>=19.6(1.1.54370)
+
+```sql
+CREATE TABLE computed.s4 (
+    time UInt64 COMMENT 'Метка времени (timestamp в ms)',
+    sat String COMMENT 'Спутник',
+    sigcomb String COMMENT 'Комбинация сигналов, для которой рассчитано значение',
+    s4 Float64 COMMENT 'S4',
+    d Date MATERIALIZED toDate(round(time / 1000))
+) ENGINE = ReplacingMergeTree(d, (time, sat, sigcomb), 8192)
+TTL d + INTERVAL 1 MONTH DELETE
+```
+
 ##### computed.s4pwr
 
 Источник: *rawdata.range*  

--- a/image_content/config/clickhouse_create_queries.sh
+++ b/image_content/config/clickhouse_create_queries.sh
@@ -207,7 +207,7 @@ FROM rawdata.satxyz2
 EOL123
 
 clickhouse-client <<EOL123
-CREATE TABLE IF NOT EXISTS computed.s4 (
+CREATE TABLE IF NOT EXISTS computed.s4pwr (
   time UInt64,
   sat String,
   freq String,

--- a/image_content/config/clickhouse_create_queries.sh
+++ b/image_content/config/clickhouse_create_queries.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# v13
+# v14
 
 clickhouse-client <<EOL123
 CREATE DATABASE IF NOT EXISTS rawdata

--- a/image_content/config/clickhouse_create_queries.sh
+++ b/image_content/config/clickhouse_create_queries.sh
@@ -207,6 +207,20 @@ FROM rawdata.satxyz2
 EOL123
 
 clickhouse-client <<EOL123
+CREATE TABLE IF NOT EXISTS computed.s4 (
+  time UInt64,
+  sat String,
+  sigcomb String,
+  s4 Float64,
+  d Date MATERIALIZED toDate(round(time / 1000))
+) ENGINE = ReplacingMergeTree()
+PARTITION BY toYYYYMM(d)
+ORDER BY (time, sat, sigcomb)
+TTL d + INTERVAL 1 MONTH DELETE
+SETTINGS index_granularity=8192
+EOL123
+
+clickhouse-client <<EOL123
 CREATE TABLE IF NOT EXISTS computed.s4pwr (
   time UInt64,
   sat String,

--- a/image_content/config/grafana-dashboards/ClickHouse New.json
+++ b/image_content/config/grafana-dashboards/ClickHouse New.json
@@ -3,26 +3,38 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "limit": 100,
         "name": "Annotations & Alerts",
         "showIn": 0,
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
         "type": "dashboard"
       }
     ]
   },
   "editable": true,
-  "gnetId": null,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 2,
-  "id": 1,
-  "iteration": 1596376253567,
   "links": [],
+  "liveNow": false,
   "panels": [
     {
       "collapsed": false,
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -31,6 +43,15 @@
       },
       "id": 17,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Данные",
       "type": "row"
     },
@@ -39,14 +60,19 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "ClickHouse",
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 12,
         "x": 0,
         "y": 1
       },
+      "hiddenSeries": false,
       "id": 8,
       "legend": {
         "alignAsTable": false,
@@ -62,8 +88,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "9.1.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -88,6 +117,10 @@
         {
           "aggregator": "sum",
           "database": "rawdata",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -109,9 +142,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Псевдодальности",
       "tooltip": {
         "shared": true,
@@ -120,9 +151,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -131,22 +160,17 @@
           "format": "lengthm",
           "label": "PSR",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "none",
           "label": "ADR",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -154,14 +178,19 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "ClickHouse",
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 12,
         "x": 12,
         "y": 1
       },
+      "hiddenSeries": false,
       "id": 2,
       "legend": {
         "alignAsTable": false,
@@ -177,8 +206,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "9.1.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -203,6 +235,10 @@
         {
           "aggregator": "sum",
           "database": "computed",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -225,6 +261,10 @@
         {
           "aggregator": "sum",
           "database": "computed",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -246,9 +286,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "ПЭС",
       "tooltip": {
         "shared": true,
@@ -257,9 +295,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -268,22 +304,17 @@
           "format": "none",
           "label": "TECU",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "none",
           "label": "ADR",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -291,14 +322,19 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "ClickHouse",
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 12,
         "x": 0,
         "y": 7
       },
+      "hiddenSeries": false,
       "id": 3,
       "legend": {
         "alignAsTable": false,
@@ -314,8 +350,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "9.1.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -332,6 +371,10 @@
         {
           "aggregator": "sum",
           "database": "rawdata",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -353,9 +396,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Псевдофазы",
       "tooltip": {
         "shared": true,
@@ -364,9 +405,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -375,22 +414,16 @@
           "format": "none",
           "label": "ADR",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "degree",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -398,14 +431,19 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "ClickHouse",
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 12,
         "x": 12,
         "y": 7
       },
+      "hiddenSeries": false,
       "id": 31,
       "legend": {
         "alignAsTable": false,
@@ -421,8 +459,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "9.1.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -447,6 +488,10 @@
         {
           "aggregator": "sum",
           "database": "rawdata",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -468,9 +513,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "ПЭС",
       "tooltip": {
         "shared": true,
@@ -479,9 +522,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -490,22 +531,17 @@
           "format": "none",
           "label": "TECU",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "none",
           "label": "ADR",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -513,14 +549,19 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "ClickHouse",
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 12,
         "x": 0,
         "y": 13
       },
+      "hiddenSeries": false,
       "id": 5,
       "legend": {
         "avg": false,
@@ -535,8 +576,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "9.1.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -728,6 +772,10 @@
       "targets": [
         {
           "database": "rawdata",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -745,6 +793,10 @@
         },
         {
           "database": "rawdata",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -762,9 +814,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "C/No",
       "tooltip": {
         "shared": true,
@@ -773,33 +823,24 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "dB",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "degree",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -807,14 +848,19 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "ClickHouse",
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 12,
         "x": 12,
         "y": 13
       },
+      "hiddenSeries": false,
       "id": 9,
       "legend": {
         "alignAsTable": false,
@@ -830,8 +876,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "9.1.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -856,6 +905,10 @@
         {
           "aggregator": "sum",
           "database": "computed",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -877,9 +930,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Среднее ПЭС",
       "tooltip": {
         "shared": true,
@@ -888,9 +939,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -899,22 +948,17 @@
           "format": "none",
           "label": "TECU",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "none",
           "label": "ADR",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -922,14 +966,19 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "ClickHouse",
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 0,
         "y": 19
       },
+      "hiddenSeries": false,
       "id": 28,
       "legend": {
         "alignAsTable": false,
@@ -945,8 +994,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "9.1.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -971,6 +1023,10 @@
         {
           "aggregator": "sum",
           "database": "computed",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -993,6 +1049,10 @@
         {
           "aggregator": "sum",
           "database": "computed",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -1014,9 +1074,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "F",
       "tooltip": {
         "shared": true,
@@ -1025,9 +1083,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -1036,22 +1092,17 @@
           "format": "hertz",
           "label": "F",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "none",
           "label": "ADR",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -1059,14 +1110,19 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "ClickHouse",
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 12,
         "x": 12,
         "y": 19
       },
+      "hiddenSeries": false,
       "id": 10,
       "legend": {
         "alignAsTable": false,
@@ -1082,8 +1138,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "9.1.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1108,6 +1167,10 @@
         {
           "aggregator": "sum",
           "database": "computed",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -1129,9 +1192,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "СКО флуктуаций ПЭС",
       "tooltip": {
         "shared": true,
@@ -1140,9 +1201,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -1151,26 +1210,25 @@
           "format": "none",
           "label": "TECU",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "none",
           "label": "ADR",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
       "collapsed": false,
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1179,6 +1237,15 @@
       },
       "id": 22,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Computed",
       "type": "row"
     },
@@ -1187,14 +1254,19 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "ClickHouse",
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 12,
         "x": 0,
         "y": 27
       },
+      "hiddenSeries": false,
       "id": 20,
       "legend": {
         "alignAsTable": false,
@@ -1210,8 +1282,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "9.1.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1236,6 +1311,10 @@
         {
           "aggregator": "sum",
           "database": "computed",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -1257,9 +1336,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "СКО флуктуаций фазы (L1)",
       "tooltip": {
         "shared": true,
@@ -1268,9 +1345,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -1279,22 +1354,17 @@
           "format": "radian",
           "label": "Radians",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "none",
           "label": "ADR",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -1302,14 +1372,19 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "ClickHouse",
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 12,
         "x": 12,
         "y": 27
       },
+      "hiddenSeries": false,
       "id": 23,
       "legend": {
         "alignAsTable": false,
@@ -1325,8 +1400,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "9.1.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1351,6 +1429,10 @@
         {
           "aggregator": "sum",
           "database": "computed",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -1372,9 +1454,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Параметр Райса (L1)",
       "tooltip": {
         "shared": true,
@@ -1383,9 +1463,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -1394,22 +1472,17 @@
           "format": "none",
           "label": "",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "none",
           "label": "ADR",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -1417,14 +1490,19 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "ClickHouse",
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 12,
         "x": 0,
         "y": 33
       },
+      "hiddenSeries": false,
       "id": 24,
       "legend": {
         "alignAsTable": false,
@@ -1440,8 +1518,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "9.1.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1466,6 +1547,10 @@
         {
           "aggregator": "sum",
           "database": "computed",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -1487,9 +1572,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Интервал частотной корреляции (L1)",
       "tooltip": {
         "shared": true,
@@ -1498,9 +1581,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -1509,22 +1590,17 @@
           "format": "hertz",
           "label": "",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "none",
           "label": "ADR",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -1532,14 +1608,19 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "ClickHouse",
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 12,
         "x": 12,
         "y": 33
       },
+      "hiddenSeries": false,
       "id": 25,
       "legend": {
         "alignAsTable": false,
@@ -1555,8 +1636,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "9.1.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1581,6 +1665,10 @@
         {
           "aggregator": "sum",
           "database": "computed",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -1602,9 +1690,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Интервал пространственной корреляции (L1)",
       "tooltip": {
         "shared": true,
@@ -1613,9 +1699,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -1624,26 +1708,25 @@
           "format": "lengthm",
           "label": "",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "none",
           "label": "ADR",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
       "collapsed": false,
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1652,12 +1735,20 @@
       },
       "id": 15,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Карты",
       "type": "row"
     },
     {
       "aliasColors": {},
-      "cacheTimeout": null,
       "colorize": false,
       "colors": [
         "#5b94ff",
@@ -1665,7 +1756,10 @@
         "#fff882",
         "#ff5b5b"
       ],
-      "datasource": "ClickHouse",
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "fontSize": "80%",
       "gridPos": {
         "h": 16,
@@ -1676,7 +1770,6 @@
       "heatmap": true,
       "heatmapField": "S4",
       "id": 7,
-      "interval": null,
       "legend": {
         "show": false
       },
@@ -1684,7 +1777,6 @@
       "links": [],
       "maxDataPoints": 2,
       "nullPointMode": "connected",
-      "options": {},
       "polar": false,
       "polarCenter": {
         "lat": 45.040638,
@@ -1694,6 +1786,10 @@
       "targets": [
         {
           "database": "rawdata",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -1722,7 +1818,6 @@
     },
     {
       "aliasColors": {},
-      "cacheTimeout": null,
       "colorize": false,
       "colors": [
         "#5b94ff",
@@ -1730,7 +1825,10 @@
         "#fff882",
         "#ff5b5b"
       ],
-      "datasource": "ClickHouse",
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "fontSize": "80%",
       "gridPos": {
         "h": 16,
@@ -1741,7 +1839,6 @@
       "heatmap": false,
       "heatmapField": "S4",
       "id": 11,
-      "interval": null,
       "legend": {
         "show": false
       },
@@ -1749,7 +1846,6 @@
       "links": [],
       "maxDataPoints": 2,
       "nullPointMode": "connected",
-      "options": {},
       "polar": false,
       "polarCenter": {
         "lat": 45.040638,
@@ -1759,6 +1855,10 @@
       "targets": [
         {
           "database": "rawdata",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -1787,7 +1887,6 @@
     },
     {
       "aliasColors": {},
-      "cacheTimeout": null,
       "colorize": false,
       "colors": [
         "#5b94ff",
@@ -1795,7 +1894,10 @@
         "#fff882",
         "#ff5b5b"
       ],
-      "datasource": "ClickHouse",
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "fontSize": "80%",
       "gridPos": {
         "h": 17,
@@ -1806,7 +1908,6 @@
       "heatmap": false,
       "heatmapField": "S4",
       "id": 19,
-      "interval": null,
       "legend": {
         "show": true
       },
@@ -1815,7 +1916,6 @@
       "links": [],
       "maxDataPoints": 2,
       "nullPointMode": "connected",
-      "options": {},
       "polar": true,
       "polarCenter": {
         "lat": 45.040638,
@@ -1826,6 +1926,10 @@
         {
           "aggregator": "sum",
           "database": "rawdata",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -1859,14 +1963,19 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "ClickHouse",
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 12,
         "x": 12,
         "y": 56
       },
+      "hiddenSeries": false,
       "id": 29,
       "legend": {
         "alignAsTable": false,
@@ -1882,8 +1991,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "9.1.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1908,6 +2020,10 @@
         {
           "aggregator": "sum",
           "database": "computed",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -1929,9 +2045,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "АКФ (L1)",
       "tooltip": {
         "shared": true,
@@ -1940,9 +2054,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -1951,26 +2063,25 @@
           "format": "none",
           "label": "",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "none",
           "label": "ADR",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
       "collapsed": false,
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1979,6 +2090,15 @@
       },
       "id": 13,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Видимость спутников",
       "type": "row"
     },
@@ -1987,14 +2107,19 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "ClickHouse",
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 12,
         "x": 0,
         "y": 74
       },
+      "hiddenSeries": false,
       "id": 27,
       "legend": {
         "alignAsTable": false,
@@ -2010,8 +2135,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "9.1.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2036,6 +2164,10 @@
         {
           "aggregator": "sum",
           "database": "computed",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -2052,14 +2184,12 @@
           "rawQuery": "SELECT t, groupArray((concat('B ', sat), s4)) as groupArr FROM ( SELECT intDiv(time, 500) * 500 as t, sat, avg(s4 / 100) s4 FROM computed.s4 WHERE d BETWEEN toDate(1595878988378/1000) AND toDate(1595879279537/1000) AND time BETWEEN 1595878988378 AND 1595879279537 AND  sat = 'GPS30' GROUP BY t, sat  ORDER BY t, sat) GROUP BY t ORDER BY t",
           "refId": "A",
           "round": "0s",
-          "table": "s4",
+          "table": "s4pwr",
           "tableLoading": false
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "B",
       "tooltip": {
         "shared": true,
@@ -2068,9 +2198,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -2079,22 +2207,17 @@
           "format": "percentunit",
           "label": "",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "none",
           "label": "ADR",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -2102,14 +2225,19 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "ClickHouse",
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 12,
         "x": 12,
         "y": 74
       },
+      "hiddenSeries": false,
       "id": 26,
       "legend": {
         "alignAsTable": false,
@@ -2125,8 +2253,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "9.1.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2151,6 +2282,10 @@
         {
           "aggregator": "sum",
           "database": "computed",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -2167,15 +2302,13 @@
           "rawQuery": "SELECT t, groupArray((concat('S4 ', sat, ' ', freq), s4)) as groupArr FROM ( SELECT intDiv(time, 500) * 500 as t, sat, freq, avg(s4) s4 FROM computed.s4 WHERE d BETWEEN toDate(1595878988378/1000) AND toDate(1595879279537/1000) AND time BETWEEN 1595878988378 AND 1595879279537 AND      freq IN ('L1CA')     AND sat = 'GPS30' GROUP BY t, sat, freq  ORDER BY t, sat, freq) GROUP BY t ORDER BY t",
           "refId": "A",
           "round": "0s",
-          "table": "s4",
+          "table": "s4pwr",
           "tableLoading": false
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
-      "title": "S4",
+      "title": "Мощностной S4",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2183,9 +2316,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -2194,22 +2325,17 @@
           "format": "none",
           "label": "",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "none",
           "label": "ADR",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -2217,14 +2343,139 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "ClickHouse",
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 12,
         "x": 12,
         "y": 80
       },
+      "hiddenSeries": false,
+      "id": 32,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.1.3",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "/Возвышение/",
+          "yaxis": 2
+        },
+        {
+          "alias": "ADR GPS5 L1",
+          "yaxis": 2
+        },
+        {
+          "alias": "ADR GPS5 L2",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "aggregator": "sum",
+          "database": "computed",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
+          "dateColDataType": "",
+          "dateLoading": false,
+          "dateTimeColDataType": "time",
+          "dateTimeType": "TIMESTAMPMS",
+          "datetimeLoading": false,
+          "downsampleAggregator": "avg",
+          "downsampleFillPolicy": "none",
+          "extrapolate": true,
+          "format": "time_series",
+          "formattedQuery": "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t ORDER BY t",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "query": "$columns(\n    'S4 %sat %sigcomb',\n    avg(s4) s4)\nFROM $table\nWHERE\n    sigcomb IN ($sigcomb)\n    AND sat = '$satgraph'",
+          "rawQuery": "SELECT t, groupArray((concat('S4 ', sat, ' ', sigcomb), s4)) AS groupArr FROM ( SELECT (intDiv(time, (1 * 1000)) * (1 * 1000)) AS t, sat, sigcomb, avg(s4) s4 FROM computed.s4\nWHERE time >= toUInt64(1664045927 * 1000) AND time <= toUInt64(1664047727 * 1000) AND\n    sigcomb IN ('L1CA+L2CA','L1CA+L2P')\n    AND sat = 'GLONASS2' GROUP BY t, sat, sigcomb ORDER BY t, sat, sigcomb) GROUP BY t ORDER BY t",
+          "refId": "A",
+          "round": "0s",
+          "skip_comments": true,
+          "table": "s4",
+          "tableLoading": false
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "S4",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "none",
+          "label": "ADR",
+          "logBase": 1,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 86
+      },
+      "hiddenSeries": false,
       "id": 30,
       "legend": {
         "alignAsTable": false,
@@ -2240,8 +2491,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "9.1.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2266,6 +2520,10 @@
         {
           "aggregator": "sum",
           "database": "rawdata",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -2287,10 +2545,8 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
-      "title": "S4",
+      "title": "Сырой S4",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2298,9 +2554,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -2309,35 +2563,36 @@
           "format": "none",
           "label": "",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "none",
           "label": "ADR",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     }
   ],
   "refresh": false,
-  "schemaVersion": 18,
+  "schemaVersion": 37,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
-        "allValue": null,
-        "current": {},
-        "datasource": "ClickHouse",
+        "current": {
+          "selected": false,
+          "text": "GLONASS2",
+          "value": "GLONASS2"
+        },
+        "datasource": {
+          "type": "vertamedia-clickhouse-datasource",
+          "uid": "PDEE91DDB90597936"
+        },
         "definition": "",
         "hide": 0,
         "includeAll": false,
@@ -2351,15 +2606,20 @@
         "skipUrlSync": false,
         "sort": 3,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
       },
       {
-        "allValue": null,
-        "current": {},
-        "datasource": "ClickHouse",
+        "current": {
+          "selected": false,
+          "text": "GLONASS2",
+          "value": "GLONASS2"
+        },
+        "datasource": {
+          "type": "vertamedia-clickhouse-datasource",
+          "uid": "PDEE91DDB90597936"
+        },
         "definition": "",
         "hide": 0,
         "includeAll": false,
@@ -2373,19 +2633,23 @@
         "skipUrlSync": false,
         "sort": 3,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
       },
       {
-        "allValue": null,
-        "current": {},
-        "datasource": "ClickHouse",
+        "current": {
+          "selected": false,
+          "text": "L1CA",
+          "value": "L1CA"
+        },
+        "datasource": {
+          "type": "vertamedia-clickhouse-datasource",
+          "uid": "PDEE91DDB90597936"
+        },
         "definition": "select distinct(freq) from rawdata.range where sat='$satgraph' and time between $__from and $__to",
         "hide": 0,
         "includeAll": false,
-        "label": null,
         "multi": true,
         "name": "freq",
         "options": [],
@@ -2395,19 +2659,23 @@
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
       },
       {
-        "allValue": null,
-        "current": {},
-        "datasource": "ClickHouse",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "vertamedia-clickhouse-datasource",
+          "uid": "PDEE91DDB90597936"
+        },
         "definition": "select distinct(sigcomb) from computed.NT where sat='$satgraph' and time between $__from and $__to",
         "hide": 0,
         "includeAll": true,
-        "label": null,
         "multi": true,
         "name": "sigcomb",
         "options": [],
@@ -2417,25 +2685,23 @@
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
       },
       {
-        "allValue": null,
         "current": {
-          "text": "L2C + L5Q",
-          "value": [
-            "L2C",
-            "L5Q"
-          ]
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
         },
-        "datasource": "ClickHouse",
+        "datasource": {
+          "type": "vertamedia-clickhouse-datasource",
+          "uid": "PDEE91DDB90597936"
+        },
         "definition": "select distinct(secondaryfreq) from rawdata.ismrawtec where sat='$satgraph' and time between $__from and $__to",
         "hide": 0,
         "includeAll": true,
-        "label": null,
         "multi": true,
         "name": "TEC_secondaryfreq",
         "options": [],
@@ -2445,7 +2711,6 @@
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -2484,5 +2749,6 @@
   "timezone": "",
   "title": "ClickHouse New",
   "uid": "0F2yyfCWz",
-  "version": 11
+  "version": 1,
+  "weekStart": ""
 }

--- a/image_content/config/grafana-dashboards/Суточный мониторинг.json
+++ b/image_content/config/grafana-dashboards/Суточный мониторинг.json
@@ -3,25 +3,38 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "limit": 100,
         "name": "Annotations & Alerts",
         "showIn": 0,
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
         "type": "dashboard"
       }
     ]
   },
   "editable": true,
-  "gnetId": null,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 2,
-  "iteration": 1656772010860,
   "links": [],
+  "liveNow": false,
   "panels": [
     {
       "collapsed": false,
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -30,6 +43,15 @@
       },
       "id": 17,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Данные",
       "type": "row"
     },
@@ -38,14 +60,19 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "ClickHouse",
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 12,
         "x": 0,
         "y": 1
       },
+      "hiddenSeries": false,
       "id": 2,
       "legend": {
         "alignAsTable": false,
@@ -61,8 +88,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "9.1.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -87,6 +117,10 @@
         {
           "aggregator": "sum",
           "database": "computed",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -108,9 +142,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "ПЭС",
       "tooltip": {
         "shared": true,
@@ -119,9 +151,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -130,22 +160,17 @@
           "format": "none",
           "label": "TECU",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "none",
           "label": "ADR",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -153,14 +178,19 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "ClickHouse",
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 12,
         "x": 12,
         "y": 1
       },
+      "hiddenSeries": false,
       "id": 5,
       "legend": {
         "avg": false,
@@ -175,8 +205,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "9.1.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -368,6 +401,10 @@
       "targets": [
         {
           "database": "computed",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -385,6 +422,10 @@
         },
         {
           "database": "computed",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -402,9 +443,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "C/No",
       "tooltip": {
         "shared": true,
@@ -413,33 +452,24 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "dB",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "degree",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -447,14 +477,19 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "ClickHouse",
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 12,
         "x": 0,
         "y": 7
       },
+      "hiddenSeries": false,
       "id": 31,
       "legend": {
         "alignAsTable": false,
@@ -470,8 +505,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "9.1.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -496,6 +534,10 @@
         {
           "aggregator": "sum",
           "database": "computed",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -517,9 +559,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "ПЭС ОЕМ6",
       "tooltip": {
         "shared": true,
@@ -528,9 +568,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -539,22 +577,17 @@
           "format": "none",
           "label": "TECU",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "none",
           "label": "ADR",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -562,14 +595,19 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "ClickHouse",
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 12,
         "x": 12,
         "y": 7
       },
+      "hiddenSeries": false,
       "id": 9,
       "legend": {
         "alignAsTable": false,
@@ -585,8 +623,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "9.1.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -611,6 +652,10 @@
         {
           "aggregator": "sum",
           "database": "computed",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -632,9 +677,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Среднее ПЭС",
       "tooltip": {
         "shared": true,
@@ -643,9 +686,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -654,27 +695,21 @@
           "format": "none",
           "label": "TECU",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "none",
           "label": "ADR",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
       "aliasColors": {},
-      "cacheTimeout": null,
       "colorize": false,
       "colors": [
         "#5b94ff",
@@ -682,7 +717,10 @@
         "#fff882",
         "#ff5b5b"
       ],
-      "datasource": "ClickHouse",
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "fontSize": "80%",
       "gridPos": {
         "h": 16,
@@ -693,7 +731,6 @@
       "heatmap": true,
       "heatmapField": "S4",
       "id": 7,
-      "interval": null,
       "legend": {
         "show": false
       },
@@ -701,7 +738,6 @@
       "links": [],
       "maxDataPoints": 2,
       "nullPointMode": "connected",
-      "options": {},
       "polar": false,
       "polarCenter": {
         "lat": 45.040638,
@@ -711,6 +747,10 @@
       "targets": [
         {
           "database": "computed",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -742,14 +782,19 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "ClickHouse",
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 12,
         "x": 12,
         "y": 13
       },
+      "hiddenSeries": false,
       "id": 32,
       "legend": {
         "alignAsTable": false,
@@ -765,8 +810,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "9.1.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -791,6 +839,10 @@
         {
           "aggregator": "sum",
           "database": "computed",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -812,9 +864,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "СКО флуктуаций ПЭС",
       "tooltip": {
         "shared": true,
@@ -823,9 +873,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -834,22 +882,17 @@
           "format": "none",
           "label": "TECU",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "none",
           "label": "ADR",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -857,14 +900,19 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "ClickHouse",
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 12,
         "x": 12,
         "y": 19
       },
+      "hiddenSeries": false,
       "id": 26,
       "legend": {
         "alignAsTable": false,
@@ -880,8 +928,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "9.1.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -906,6 +957,10 @@
         {
           "aggregator": "sum",
           "database": "computed",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -922,15 +977,13 @@
           "rawQuery": "SELECT t, groupArray((concat('S4 ', sat, ' ', freq), s4)) as groupArr FROM ( SELECT intDiv(time, 15000) * 15000 as t, sat, freq, avg(s4) s4 FROM computed.s4 WHERE d >= toDate(1656762638574/1000) AND time >= 1656762638574 AND      freq IN ('L1CA')     AND sat = 'GLONASS1' GROUP BY t, sat, freq  ORDER BY t, sat, freq) GROUP BY t ORDER BY t",
           "refId": "A",
           "round": "0s",
-          "table": "s4",
+          "table": "s4pwr",
           "tableLoading": false
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
-      "title": "S4",
+      "title": "Мощностной S4",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -938,9 +991,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -949,22 +1000,17 @@
           "format": "none",
           "label": "",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "none",
           "label": "ADR",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -972,15 +1018,20 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "ClickHouse",
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 12,
         "x": 12,
         "y": 25
       },
-      "id": 30,
+      "hiddenSeries": false,
+      "id": 33,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -995,8 +1046,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "9.1.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1021,6 +1075,130 @@
         {
           "aggregator": "sum",
           "database": "computed",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
+          "dateColDataType": "",
+          "dateLoading": false,
+          "dateTimeColDataType": "time",
+          "dateTimeType": "TIMESTAMPMS",
+          "datetimeLoading": false,
+          "downsampleAggregator": "avg",
+          "downsampleFillPolicy": "none",
+          "extrapolate": true,
+          "format": "time_series",
+          "formattedQuery": "SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter GROUP BY t ORDER BY t",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "query": "$columns(\n    'S4 %sat %sigcomb',\n    avg(s4) s4)\nFROM $table\nWHERE\n    sigcomb IN ($sigcomb)\n    AND sat = '$satgraph'",
+          "rawQuery": "SELECT t, groupArray((concat('S4 ', sat, ' ', sigcomb), s4)) AS groupArr FROM ( SELECT (intDiv(time, (5 * 1000)) * (5 * 1000)) AS t, sat, sigcomb, avg(s4) s4 FROM computed.s4\nWHERE time >= toUInt64(1664038327 * 1000) AND time <= toUInt64(1664049127 * 1000) AND\n    sigcomb IN ('L1CA+L2CA','L1CA+L2P')\n    AND sat = 'GLONASS1' GROUP BY t, sat, sigcomb ORDER BY t, sat, sigcomb) GROUP BY t ORDER BY t",
+          "refId": "A",
+          "round": "0s",
+          "skip_comments": true,
+          "table": "s4",
+          "tableLoading": false
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "S4",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "none",
+          "label": "ADR",
+          "logBase": 1,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "PDEE91DDB90597936"
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 31
+      },
+      "hiddenSeries": false,
+      "id": 30,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.1.3",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "/Возвышение/",
+          "yaxis": 2
+        },
+        {
+          "alias": "ADR GPS5 L1",
+          "yaxis": 2
+        },
+        {
+          "alias": "ADR GPS5 L2",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "aggregator": "sum",
+          "database": "computed",
+          "datasource": {
+            "type": "vertamedia-clickhouse-datasource",
+            "uid": "PDEE91DDB90597936"
+          },
           "dateColDataType": "d",
           "dateLoading": false,
           "dateTimeColDataType": "time",
@@ -1042,9 +1220,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "S4 ОЕМ6",
       "tooltip": {
         "shared": true,
@@ -1053,9 +1229,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -1064,40 +1238,40 @@
           "format": "none",
           "label": "",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "none",
           "label": "ADR",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     }
   ],
   "refresh": "10s",
-  "schemaVersion": 18,
+  "schemaVersion": 37,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
-        "allValue": null,
         "current": {
-          "text": "GLONASS1",
+          "selected": true,
+          "text": [
+            "GLONASS1"
+          ],
           "value": [
             "GLONASS1"
           ]
         },
-        "datasource": "ClickHouse",
+        "datasource": {
+          "type": "vertamedia-clickhouse-datasource",
+          "uid": "PDEE91DDB90597936"
+        },
         "definition": "select distinct(sat) from computed.satxyz2 where time between $__from and $__to",
         "hide": 0,
         "includeAll": false,
@@ -1111,18 +1285,20 @@
         "skipUrlSync": false,
         "sort": 3,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
       },
       {
-        "allValue": null,
         "current": {
+          "selected": false,
           "text": "GLONASS1",
           "value": "GLONASS1"
         },
-        "datasource": "ClickHouse",
+        "datasource": {
+          "type": "vertamedia-clickhouse-datasource",
+          "uid": "PDEE91DDB90597936"
+        },
         "definition": "select distinct(sat) from computed.satxyz2 where time between $__from and $__to",
         "hide": 0,
         "includeAll": false,
@@ -1136,22 +1312,27 @@
         "skipUrlSync": false,
         "sort": 3,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
       },
       {
-        "allValue": null,
         "current": {
-          "text": "L1CA",
-          "value": "L1CA"
+          "selected": true,
+          "text": [
+            "L1CA"
+          ],
+          "value": [
+            "L1CA"
+          ]
         },
-        "datasource": "ClickHouse",
+        "datasource": {
+          "type": "vertamedia-clickhouse-datasource",
+          "uid": "PDEE91DDB90597936"
+        },
         "definition": "select distinct(freq) from computed.range where sat='$satgraph' and time between $__from and $__to",
         "hide": 0,
         "includeAll": false,
-        "label": null,
         "multi": true,
         "name": "freq",
         "options": [],
@@ -1161,23 +1342,27 @@
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
       },
       {
-        "allValue": null,
         "current": {
           "selected": true,
-          "text": "All",
-          "value": "$__all"
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
-        "datasource": "ClickHouse",
+        "datasource": {
+          "type": "vertamedia-clickhouse-datasource",
+          "uid": "PDEE91DDB90597936"
+        },
         "definition": "select distinct(sigcomb) from computed.NT where sat='$satgraph' and time between $__from and $__to",
         "hide": 0,
         "includeAll": true,
-        "label": null,
         "multi": true,
         "name": "sigcomb",
         "options": [],
@@ -1187,22 +1372,27 @@
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
       },
       {
-        "allValue": null,
         "current": {
-          "text": "All",
-          "value": "$__all"
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
-        "datasource": "ClickHouse",
+        "datasource": {
+          "type": "vertamedia-clickhouse-datasource",
+          "uid": "PDEE91DDB90597936"
+        },
         "definition": "select distinct(secondaryfreq) from computed.ismrawtec where sat='$satgraph' and time between $__from and $__to",
         "hide": 0,
         "includeAll": true,
-        "label": null,
         "multi": true,
         "name": "TEC_secondaryfreq",
         "options": [],
@@ -1212,7 +1402,6 @@
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -1251,5 +1440,6 @@
   "timezone": "",
   "title": "Суточный мониторинг",
   "uid": "0F2yyfCWz3",
-  "version": 1
+  "version": 1,
+  "weekStart": ""
 }


### PR DESCRIPTION
Этот PR добавляет забытый функционал для $S_4(\sigma_\varphi)$.
До текущего PR вычислялась $S_4(P)$, что бессмысленно.

**Breaking changes:**

- Изменена структура таблицы `computed.s4`, т.к. эта $S_4$ вычисляется
  *для комбинации частот*.
- Данные $S_4(P)$ перенаправляются в `computed.s4pwr`. Это может измениться в будущем.