### PR TITLE
Add Jupyter Lab container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,17 @@ services:
     depends_on:
       - clickhouse
 
+  # Jupyter Lab
+  # Docs: https://jupyter-docker-stacks.readthedocs.io
+  jupyter:
+    container_name: ionosphere-iif-jupyter
+    profiles: ["jupyter"]
+    image: jupyter/pyspark-notebook:spark-3.3.1
+    ports:
+      - 8888:8888
+    volumes:
+      - './docs/jupyter/:/home/jovyan/work'
+
   reporter:
     container_name: ionosphere-iif-reporter
     profiles: ["reporter"]

--- a/docs/jupyter/ClickHouseExample.ipynb
+++ b/docs/jupyter/ClickHouseExample.ipynb
@@ -1,0 +1,110 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "76987010-5080-4115-bd93-4cf3ef569dd2",
+   "metadata": {},
+   "source": [
+    "Пример взаимодействия с ClickHouse\n",
+    "==================================\n",
+    "\n",
+    "На [основе][altinity].\n",
+    "\n",
+    "[altinity]: https://altinity.com/blog/2019/2/25/clickhouse-and-python-jupyter-notebooks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de0f5891-4773-4fe4-9233-edcc8b0532f8",
+   "metadata": {},
+   "source": [
+    "Установить пакеты для работы с ClickHouse:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f5b4b5d-4839-4bb0-b7bc-c055f12ea6c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install a conda packages in the current Jupyter kernel\n",
+    "import sys\n",
+    "\n",
+    "!conda install --yes --prefix {sys.prefix} -c conda-forge clickhouse-driver clickhouse-sqlalchemy ipython-sql"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9baeb69-a4df-4a46-9051-e0fe23229f43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sqlalchemy import create_engine"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b79c30d-c706-4f05-a61a-2fd48442279b",
+   "metadata": {},
+   "source": [
+    "Подгрузить SQL magic:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e57880f9-6585-4332-bfd1-339970c6f4e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext sql"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40eedc6b-29ef-41ba-9778-26c624a469b2",
+   "metadata": {},
+   "source": [
+    "Сделать тестовый запрос:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df41df94-1dea-4894-8da4-a67bd766446b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%sql clickhouse://default:@clickhouse/default\n",
+    "result = %sql SELECT * FROM rawdata.range ORDER BY time DESC LIMIT 100\n",
+    "df = result.DataFrame()\n",
+    "df"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Добавляет начальную поддержку Jupyter в виде опционального сервиса.
Используется официальный образ [Jupyter Lab с поддержкой Spark][1]
([дополнительные инструкции к образу][2]).

Jupyter Lab должен облегчить прототипирование и заменить MATLAB.
Так же, имея возможность подключения напрямую к кластеру позволит
отказаться от использования выгрузок в файл.

[1]: https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-pyspark-notebook
[2]: https://jupyter-docker-stacks.readthedocs.io/en/latest/using/specifics.html#apache-spark