### PR TITLE
build!: Update gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "logserver-spark"]
 	path = logserver-spark
-	url = https://github.com/mixayloff-dimaaylov/ionosphere
+	url = https://github.com/mixayloff-dimaaylov/logserver-spark
 	branch = master
 [submodule "clickhouse-grafana"]
 	path = clickhouse-grafana

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,7 @@
 	path = satmap-panel
 	url = https://github.com/mixayloff-dimaaylov/satmap-panel
 	branch = clickhouse-ng
+[submodule "NovAtelLogReader"]
+	path = NovAtelLogReader
+	url = https://github.com/mixayloff-dimaaylov/NovAtelLogReader
+	branch = master


### PR DESCRIPTION
## Summary

Обновления [.gitmodules](.gitmodules).

## Details

- Репозиторий `logserver-spark` переименован таким, каким оно предполагался
  изначально
- Добавлен субмодуль `NovAtelLogReader`.

## Breaking changes

- Репозиторий `logserver-spark` переименован, что может повлиять на доступ к
  старой истории по старому адресу (хотя сама история нетронута)