### PR TITLE
fix(logserver-spark): Set receiver coordinates from ARGV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # docker-compose environment file
 .env
+docker-compose.override.yml
 
 # JupyterLab checkpointing
 **/.ipynb_checkpoints/

--- a/README.md
+++ b/README.md
@@ -24,12 +24,38 @@ docker-compose --profile default build
 
 2. Указать настройки для кластера
 
-Настройки указываются в `.env`-файла Docker Compose через переменные среды:
+Настройки указываются в `docker-compose.override.yml`-файла Docker Compose через
+переменные среды:
 
-```sh
-# Физический адрес необходим NovAtelLogReader при обращении к Kafka
-# если NovAtelLogReader расположен на другом хосте
-echo "KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://<ip_адрес>:9092" >> .env
+```yaml
+version: "3.4"
+
+services:
+  kafka:
+    environment:
+      # Физический адрес необходим NovAtelLogReader при обращении к Kafka
+      # если NovAtelLogReader расположен на другом хосте
+      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://<ip_адрес>:9092
+
+  spark-teccalculationv2:
+    environment:
+      # Координаты приёмника
+      REC_LAT: '45.0409515'
+      REC_LON: '41.9108996'
+      REC_ALT: '652.1387'
+
+  reporter:
+    environment:
+      # Часовой пояс для скриншотов
+      REPORTER_TZ: 'Europe/Moscow'
+    volumes:
+      # Раздел для сохранения скриншотов
+      - '/data/grafana-reporter/archives/:/usr/src/app/archives'
+
+  reporter-webdriver:
+    environment:
+      # Часовой пояс для скриншотов
+      WEBDRIVER_TZ: 'Europe/Moscow'
 ```
 
 3. Запустить кластер 


### PR DESCRIPTION
## Summary

Требует установку координат GPS-приёмника в Compose-файле вместо использования
фиксированных в коде координат.

## Details

Координаты приёмника должны не должны быть привязаны к единственному месту на
Земле, иначе невозможно корректное использовать ПО во всех остальных случаях.
Теперь координаты приёмника являются **обязательными** аргументами исполняемого
файла при запуске кластера.

В данном проекте эти переменные устанавливаются в Compose-файле либо
переопределяются в [override][override]-файле.

## Breaking changes

- Координаты GPS-приёмника теперь обязательны в Docker compose. Их можно указать
  при помощи Compose [override][override]-файла.
  - mixayloff-dimaaylov/logserver-spark#19

[override]: https://docs.docker.com/compose/extends/