### PR TITLE
perf: Optimize Clickhouse `computed.*` tables duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@
 - **dependencies:** Обновление Grafana с `9.1.3` до `9.5.1`
   ([#58](https://github.com/mixayloff-dimaaylov/gstma/pull/58))
 
-- **breaking(API):** Версия таблиц ClickHouse обновлена с 16.1 до 18
+- **breaking(API):** Версия таблиц ClickHouse обновлена с 16.1 до 19
   ([#60](https://github.com/mixayloff-dimaaylov/gstma/pull/60),
-  [#62](https://github.com/mixayloff-dimaaylov/gstma/pull/62))
+  [#62](https://github.com/mixayloff-dimaaylov/gstma/pull/62),
+  [#68](https://github.com/mixayloff-dimaaylov/gstma/pull/68))
 
 - **docs:** Добавлена справка по использованию Monocker для мониторинга
   состояния кластера в Telegram
@@ -57,6 +58,9 @@
   GeoMap ([#62](https://github.com/mixayloff-dimaaylov/gstma/pull/62))
 
 ### Fixed
+
+- **clickhouse:** Оптимизация используемого ClickHouse дискового пространства
+  ([#68](https://github.com/mixayloff-dimaaylov/gstma/pull/68))
 
 ### Removed
 

--- a/docs/specs/schema/clickhouse.md
+++ b/docs/specs/schema/clickhouse.md
@@ -232,17 +232,7 @@ PARTITION BY toYYYYMM(d)
 ORDER BY (time, sat)
 TTL d + INTERVAL 1 MONTH DELETE
 POPULATE AS
-SELECT
-    time,
-    geopoint,
-    geopointStr,
-    ionpoint,
-    ionpointStr,
-    elevation,
-    sat,
-    system,
-    prn,
-    d
+SELECT *, d
 FROM rawdata.satxyz2
 WHERE
     time = intDiv(time, 1000) * 1000

--- a/docs/specs/schema/clickhouse.md
+++ b/docs/specs/schema/clickhouse.md
@@ -164,24 +164,13 @@ GROUP BY
 
 Источник: *rawdata.ismredobs*  
 Частота дискретизации: 1/60 Гц  
+Привязка к существующей таблице  
 
 *Примечание:* для поддержки TTL необходима версия clickhouse>=19.6(1.1.54370)
 
 ```sql
-CREATE MATERIALIZED VIEW computed.ismredobs
-ENGINE = MergeTree
-PARTITION BY toYYYYMM(d)
-ORDER BY (time, sat, freq)
-TTL d + INTERVAL 1 MONTH DELETE
-SELECT
-    time,
-    totals4,
-    sat,
-    system,
-    freq,
-    glofreq,
-    prn,
-    d
+CREATE VIEW computed.ismredobs
+AS SELECT *, d
 FROM rawdata.ismredobs
 ```
 
@@ -219,26 +208,13 @@ GROUP BY
 
 Источник: *rawdata.ismrawtec*  
 Частота дискретизации: 1 Гц  
+Привязка к существующей таблице  
 
 *Примечание:* для поддержки TTL необходима версия clickhouse>=19.6(1.1.54370)
 
 ```sql
-CREATE MATERIALIZED VIEW computed.ismrawtec
-ENGINE = MergeTree
-PARTITION BY toYYYYMM(d)
-ORDER BY (time, sat, primaryfreq, secondaryfreq)
-TTL d + INTERVAL 1 MONTH DELETE
-POPULATE AS
-SELECT
-    time,
-    tec,
-    sat,
-    system,
-    primaryfreq,
-    secondaryfreq,
-    glofreq,
-    prn,
-    d
+CREATE VIEW computed.ismrawtec
+AS SELECT *, d
 FROM rawdata.ismrawtec
 ```
 

--- a/image_content/config/clickhouse_create_queries.sh
+++ b/image_content/config/clickhouse_create_queries.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# v18
+# v19
 
 clickhouse-client <<EOL123
 CREATE DATABASE IF NOT EXISTS rawdata
@@ -173,14 +173,18 @@ TTL d + INTERVAL 1 MONTH DELETE
 POPULATE AS
 SELECT
     time,
-    power,
+    avg(power) AS power,
     sat,
-    system,
+    any(system) AS system,
     freq,
-    glofreq,
-    prn,
-    d
+    any(glofreq) AS glofreq,
+    any(prn) AS prn,
+    any(d) AS d
 FROM rawdata.ismdetobs
+GROUP BY
+    (intDiv(time, 1000) * 1000) AS time,
+    sat,
+    freq
 EOL123
 
 clickhouse-client <<EOL123
@@ -222,6 +226,8 @@ SELECT
     prn,
     d
 FROM rawdata.satxyz2
+WHERE
+    time = intDiv(time, 1000) * 1000
 EOL123
 
 clickhouse-client <<EOL123

--- a/image_content/config/clickhouse_create_queries.sh
+++ b/image_content/config/clickhouse_create_queries.sh
@@ -353,3 +353,7 @@ CREATE TABLE IF NOT EXISTS misc.sdcb (
 ORDER BY (system, sat, sigcomb)
 SETTINGS index_granularity=8192
 EOL123
+
+clickhouse-client <<EOL123
+ALTER TABLE system.query_log MODIFY TTL event_date + INTERVAL 14 DAY;
+EOL123

--- a/image_content/config/clickhouse_create_queries.sh
+++ b/image_content/config/clickhouse_create_queries.sh
@@ -187,17 +187,7 @@ PARTITION BY toYYYYMM(d)
 ORDER BY (time, sat)
 TTL d + INTERVAL 1 MONTH DELETE
 POPULATE AS
-SELECT
-    time,
-    geopoint,
-    geopointStr,
-    ionpoint,
-    ionpointStr,
-    elevation,
-    sat,
-    system,
-    prn,
-    d
+SELECT *, d
 FROM rawdata.satxyz2
 WHERE
     time = intDiv(time, 1000) * 1000

--- a/image_content/config/clickhouse_create_queries.sh
+++ b/image_content/config/clickhouse_create_queries.sh
@@ -146,21 +146,8 @@ GROUP BY
 EOL123
 
 clickhouse-client <<EOL123
-CREATE MATERIALIZED VIEW IF NOT EXISTS computed.ismredobs
-ENGINE = MergeTree
-PARTITION BY toYYYYMM(d)
-ORDER BY (time, sat, freq)
-TTL d + INTERVAL 1 MONTH DELETE
-POPULATE AS
-SELECT
-    time,
-    totals4,
-    sat,
-    system,
-    freq,
-    glofreq,
-    prn,
-    d
+CREATE VIEW IF NOT EXISTS computed.ismredobs
+AS SELECT *, d
 FROM rawdata.ismredobs
 EOL123
 
@@ -188,22 +175,8 @@ GROUP BY
 EOL123
 
 clickhouse-client <<EOL123
-CREATE MATERIALIZED VIEW IF NOT EXISTS computed.ismrawtec
-ENGINE = MergeTree
-PARTITION BY toYYYYMM(d)
-ORDER BY (time, sat, primaryfreq, secondaryfreq)
-TTL d + INTERVAL 1 MONTH DELETE
-POPULATE AS
-SELECT
-    time,
-    tec,
-    sat,
-    system,
-    primaryfreq,
-    secondaryfreq,
-    glofreq,
-    prn,
-    d
+CREATE VIEW IF NOT EXISTS computed.ismrawtec
+AS SELECT *, d
 FROM rawdata.ismrawtec
 EOL123
 


### PR DESCRIPTION
## Summary

Оптимизация избыточного использования дискового пространства за счет исправление
недочетов структуры таблиц

## Details

Оптимизация избыточного использования дискового пространства за счет исправление
недочетов структуры таблиц:

1. `system.query_log` -- ограничение хранения для системной таблицы. Она
   занимает до 30% используемого пространства

2. `computed.ismredobs` и `computed.ismrawtec` -- использование `VIEW` без
   `MATERIALIZED` (простой синоним таблицы без выделения пространства). Эти уже
   дискретизированы с нужной частотой 1 Гц. Нет смысла дублировать данные, если
   они копируются без изменений

2. `rawdata.ismdetobs` -- усреднение с частотой 1 Гц, как и соседние
   MATERIALIZED-таблицы. До этого данные просто копировались, что избыточно и не
   имеет смысла. Отказ от лишней избыточности позволяет сэкономить дисковое
   пространство

3. `computed.satxyz2` -- использование точек, кратных секунде вместо
   интерполяции, т.к. операция усреднения GeoHash-столбцов не имеет смысла.

*Прочие исправления:*

1. `rawdata.satxyz2` -- исправлена опечатка. После использования интерполяции в
   [NovAtelLogReader#10][1] в этой таблице хранятся данные с частотой точек 50 Гц, хотя в
   структуре таблицы не было никаких изменений. Теперь это отражено

2. Исправлен уровень заголовка в файле

## Screenshots

**До внесения изменений:**
![до](https://github.com/mixayloff-dimaaylov/gstma/assets/65488726/308e86fb-54b3-40ab-b7fe-529bc69d2ab4)

**После внесения изменений:**
![после](https://github.com/mixayloff-dimaaylov/gstma/assets/65488726/dc7582d9-de5f-4be1-9421-278ae1cc14d4)

Удалось сэкономить около 135 Гб.

[1]: NovAtelLogReader#10