### PR TITLE
feat(util): Data dumps with `util/dump_yesterday.sh`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@
 - **plotter:** Добавлена кнопка загрузки файлов выгрузок через интерфейс
   браузера ([#67](https://github.com/mixayloff-dimaaylov/gstma/pull/67))
 
+- **utils:** Добавлен скрипт для выгрузки данных в формате Parquet
+  ([#69](https://github.com/mixayloff-dimaaylov/gstma/pull/69))
+
 - **docs:** Добавлена справка по подключению _Grafana Unified Alerting_ к
   Telegram ([#58](https://github.com/mixayloff-dimaaylov/gstma/pull/58))
 

--- a/docs/appnotes/datadump.md
+++ b/docs/appnotes/datadump.md
@@ -1,0 +1,30 @@
+Выгрузка данных из ClickHouse
+=============================
+
+На данный момент данных в ClickHouse хранятся ограниченное время, по истечению
+которого удаляются. При необходимости можно выгрузить данные за прошлые сутки во
+внешний файл. Для этого нужно использовать скрипт
+[util/dump_yesterday.sh][dump], который можно запустить в локальном окружении,
+если в нем установлен ClickHouse и `clickhouse-client`:
+
+```sh
+util/dump_yesterday.sh
+```
+
+Выгрузка будет сохранена в директории `/datadump`.
+
+Либо, используя docker-контейнер:
+
+```sh
+docker run --rm -it \
+       -v '/data/historical-datasets/Сияния на юге:/datadump' \
+       -w '/datadump' \
+       --network=gstma_default \
+       --entrypoint util/dump_yesterday.sh \
+       yandex/clickhouse-server:20.7
+```
+
+Формат выгрузки - [Parquet][parquet].
+
+[dump]: ../../util/dump_yesterday.sh
+[parquet]: https://parquet.apache.org

--- a/util/dump_yesterday.sh
+++ b/util/dump_yesterday.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+# stdlib
+
+print_help() {
+	printf '%s\n' \
+		"${_script} -- dump databases for current day" \
+		'' \
+		'Usage:' \
+		'' \
+		" ${_script} [-h]" \
+		'   -h - print this help and exit'
+}
+
+errexit() {
+	printf "${_script}: %b" "${1}" >&2
+	exit "${2}"
+}
+
+# funcs
+
+# $1 -- database
+# $2 -- table
+# $3 -- dump date, also used for specify path
+dump() {
+    typeset -r db="${1}" table="${2}" _date="${3}"
+
+    _target_dir="${_dump_path}/$(date +'%Y/%m/%d' -d "${_date}")"
+    _target_file="${_target_dir}/${db}.${table}.parquet"
+    mkdir -p -- "${_target_dir}"
+
+    echo "export table ${table} from database ${db}"
+
+    # dump
+    clickhouse-client --host "${_host}" -q \
+"SELECT * FROM ${db}.${table} "\
+"WHERE toDate(toDateTime64(\`time\` / 1000, 3, 'UTC')) == toDate('${_date}') "\
+"ORDER BY time ASC" \
+        --format Parquet > "${_target_file}"
+
+    chmod a-w "${_target_file}"
+}
+
+export LANG=en
+export TZ=UTC
+
+# defaults
+_script="$(basename "${0}")"
+_host='clickhouse'
+_dump_path='/datadump'
+_date="$(date -d 'yesterday')"
+_date_to="${_date}"
+
+while getopts ':h' _opt ; do
+	case "${_opt}" in
+		h)
+			print_help
+			exit 0
+			;;
+		*)
+			errexit 'No such switch. Exiting...\n' '1'
+			;;
+	esac
+done
+
+shift $((OPTIND-1))
+
+[ "${#}" -gt '2' ] && errexit "Not exact number of arguments.\n" '1'
+
+if [ "${#}" -gt '0' ] ; then
+    _date="${1}"
+    _date_to="${_date}"
+fi
+
+if [ "${#}" -gt '1' ] ; then
+    _date_to="${2}"
+fi
+
+if [ ! -d "${_dump_path}" ] ; then
+	errexit "Target directory ${_dump_path} doesn't exists. Exiting." '1'
+fi
+
+while read -r db ; do
+	if echo "${db}" | grep -iqP '(system|information_schema|default)' ; then
+		printf '%s\n' "skip system db ${db}"
+		continue 1
+	fi
+
+	while read -r table ; do
+		if [[ "${table}" == '.inner.'* ]] ; then
+			printf '%s\n' "skip materialized view ${table} (${db})"
+			continue
+		fi
+
+		if [[ "${table}" == 'sdcb' ]] ; then
+			printf '%s\n' "skip table ${table} (${db})"
+			continue
+		fi
+
+        dump "${db}" "${table}" "${_date}"
+	done < <(clickhouse-client --host "${_host}" -q "SHOW TABLES FROM ${db}")
+done < <(clickhouse-client --host "${_host}" -q 'SHOW DATABASES')


### PR DESCRIPTION
## Summary

Выгрузка данных ClickHouse в формате Parquet за прошедшие сутки.

## Details

На данный момент данных в ClickHouse хранятся ограниченное время, по истечению
которого удаляются. Данный PR добавляет скрипт `util/dump_yesterday.sh` чтобы
выгружать данные за прошлые сутки во внешний файл.

Формат Parquet дает дополнительное сжатие по сравнению с CSV. В дальнейшем можно
проводить дополнительные оптимизации за счет указания типов колонок. Например,
указать для некоторых колонок тип [`ENUM`][parquet-format].

[parquet-format]: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md