### PR TITLE
fix(clickhouse): Revert "perf(clickhouse)!: Set TTL for system.query_log table"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,8 @@
 ### Fixed
 
 - **clickhouse:** Оптимизация используемого ClickHouse дискового пространства
-  ([#68](https://github.com/mixayloff-dimaaylov/gstma/pull/68))
+  ([#68](https://github.com/mixayloff-dimaaylov/gstma/pull/68),
+   [#72](https://github.com/mixayloff-dimaaylov/gstma/pull/72))
 
 - **logserver-spark:** Исправлен расчет параметра Райса $\\gamma$
   ([#70](https://github.com/mixayloff-dimaaylov/gstma/pull/70))

--- a/image_content/config/clickhouse_create_queries.sh
+++ b/image_content/config/clickhouse_create_queries.sh
@@ -316,7 +316,3 @@ CREATE TABLE IF NOT EXISTS misc.sdcb (
 ORDER BY (system, sat, sigcomb)
 SETTINGS index_granularity=8192
 EOL123
-
-clickhouse-client <<EOL123
-ALTER TABLE system.query_log MODIFY TTL event_date + INTERVAL 14 DAY;
-EOL123


### PR DESCRIPTION
## Summary

Принудительная очистка вызывает зависание ClickHouse при запуске.

## Links

Issued-by: ae287d1 (#68)